### PR TITLE
Rewritting links within included svg files that are not in current directory.

### DIFF
--- a/jquery.svg.js
+++ b/jquery.svg.js
@@ -996,7 +996,7 @@ $.extend(SVGWrapper.prototype, {
 				var base = url.replace(/\/[^\/]*$/, '/');
 				$("*[xlink\\:href]", data.documentElement).each( function(i,el) {
 					var href = $(el).attr('xlink:href')+"";
-					if (!href.match(/(^[a-z]([-a-z0-9+.])*:.*$)|(^\/.*$)/i)) {
+					if (!href.match(/(^[a-z]([-a-z0-9+.])*:.*$)|(^\/.*$)/i) && href[0] != '#') {
 						// only consider relative href
 						$(el).attr('xlink:href', base + $(el).attr('xlink:href'));
 					}

--- a/jquery.svg.js
+++ b/jquery.svg.js
@@ -1020,7 +1020,9 @@ $.extend(SVGWrapper.prototype, {
 				wrapper.configure(parent, {width: size[0], height: size[1]});
 			}
 			if (settings.onLoad) {
-				settings.onLoad.apply(wrapper._container || wrapper._svg, [wrapper]);
+				var w = data.documentElement.getAttribute('width');
+				var h = data.documentElement.getAttribute('height');
+				settings.onLoad.apply(wrapper._container || wrapper._svg, [wrapper, w, h]);
 			}
 		};
 		if (url.match('<svg')) { // Inline SVG

--- a/jquery.svg.js
+++ b/jquery.svg.js
@@ -992,6 +992,16 @@ $.extend(SVGWrapper.prototype, {
 					(messages.length ? messages[0] : errors[0]).firstChild.nodeValue);
 				return;
 			}
+			if (!settings.forceKeepRelativePath && url.search(/\//) != -1) {
+				var base = url.replace(/\/[^\/]*$/, '/');
+				$("*[xlink\\:href]", data.documentElement).each( function(i,el) {
+					var href = $(el).attr('xlink:href')+"";
+					if (!href.match(/(^[a-z]([-a-z0-9+.])*:.*$)|(^\/.*$)/i)) {
+						// only consider relative href
+						$(el).attr('xlink:href', base + $(el).attr('xlink:href'));
+					}
+				});
+			}
 			var parent = (settings.parent ? $(settings.parent)[0] : wrapper._svg);
 			var attrs = {};
 			for (var i = 0; i < data.documentElement.attributes.length; i++) {


### PR DESCRIPTION
Hi Keith,

(I'm Rémi, and sent you a mail recently, about the download button on your page, but this is unrelated)

Here is the motivation of the pull request.

When I have an html page and use jquery to load an svg in a subfolder, the svg is loaded as expected. However, if the svg file contained relative links inside (link to images or hyperlinks), these become wrong. More exactly, they change meaning: the paths were expressed relative to the SVG file but they are now within the html page and thus represent things relative to the html page.

I made a patch to jquery svg to rewrite these relative links. The pull request contains this, together with adding some information to the onLoad callbacks: the width and the height of the svg element (before it gets lost by the embedding into html).

I have also a branch "test-patches"¹ that provides some html and svg files to illustrate the patches.

Cheers,
Rémi

¹: https://github.com/twitwi/svg/tree/test-patches
